### PR TITLE
rejig the multiple lighting systems

### DIFF
--- a/engineermainarduino/engineermainarduino.ino
+++ b/engineermainarduino/engineermainarduino.ino
@@ -496,7 +496,7 @@ void stateOff() {
   ringLightState = false;
 
   // ------clear reactor leds
-  for (int i = 0; i < 5; i++) {
+  for (int i = 0; i < NUM_PANEL_LEDS; i++) {
     leds[i] = CRGB::Black;
   }
   *ledReactor = CRGB::Black;


### PR DESCRIPTION
The main change is a bunch of named arrays that index the main LED array, starting on the offset of where the LED cluster is. So `ledRings[0][0]` points at `leds[5]`. Additionally, all the raw colour sets have been replaced with constants. These two lay the groundwork for easier spinny LEDs and HSV based brightness modulation.
I've also run the arduino "reformat" command to get rid of all the random newlines, cramped operators and trailing spaces. 
